### PR TITLE
[ 開発環境 ] queue-task.yml: 取り込み時ラベルを status:awaiting-approval に更新

### DIFF
--- a/.github/workflows/queue-task.yml
+++ b/.github/workflows/queue-task.yml
@@ -21,7 +21,7 @@ jobs:
             const execType = labels.includes('parallel') ? 'parallel' : 'sequential';
             const priority = labels.find(l => l.startsWith('priority:')) || null;
 
-            const taskLabels = ['status:pending', execType];
+            const taskLabels = ['status:awaiting-approval', execType];
             if (priority) taskLabels.push(priority);
 
             // 重複チェック


### PR DESCRIPTION
## 概要

`task-queue` リポジトリで「取り込み時の自動実行を止め、`status:awaiting-approval` → `status:ready` の承認フローを導入」する仕様変更が行われました（vektor-inc/task-queue#17）。本 PR は配布済みの `.github/workflows/queue-task.yml` を最新版に同期します。

これにより、本リポジトリの issue に `task-queue` ラベルが付いたとき、task-queue 側に作成される issue のラベルが旧 `status:pending` ではなく新 `status:awaiting-approval` になります。

## 変更内容

- `.github/workflows/queue-task.yml` を task-queue の最新テンプレートに差し替え（実質変更は `taskLabels` の `status:pending` → `status:awaiting-approval`）

## 確認手順

### 前提条件
- 本リポジトリに `task-queue` ラベルが存在する

### 手順
1. このリポジトリで適当な issue を作成する（または既存 issue を使う）
2. issue に `task-queue` ラベルを付与する
3. https://github.com/vektor-inc/task-queue/issues を開く
   → ✓ 該当 issue が `[<このリポ名>] <タイトル>` の形で作成されている
   → ✓ ラベルが `status:awaiting-approval` になっている（`status:pending` ではない）

## 補足

開発インフラ（CI ワークフロー）の設定ファイル更新のため、リリースノート（changelog）対象外です。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **その他**
  * タスク投入時のステータスラベルの処理ロジックを更新しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/bill-vektor-attendance/pull/2)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->